### PR TITLE
isolate bash to Makefile, handle mocha PATH

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
+sudo: false
 node_js:
   - "0.10"
   - "0.12"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: node_js
-sudo: false
 node_js:
   - "0.10"
   - "0.12"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ node_js:
   - "0.12"
 services: mongodb
 script: make travis
-after_script: npm install coveralls && cat ./coverage/lcov.info | coveralls
+after_script: make report

--- a/Makefile
+++ b/Makefile
@@ -23,11 +23,11 @@ coverage:
 	${ISTANBUL} cover ${MOCHA} -- -R tap ${TESTS}
 
 report:
-	npm install coveralls && cat ./coverage/lcov.info | ./node_modules/.bin/coveralls
+	test -f ./coverage/lcov.info && (npm install coveralls && cat ./coverage/lcov.info | ./node_modules/.bin/coveralls) || echo "NO COVERAGE"
 
 test:
 	${MONGO_SETTINGS} ${MOCHA} -R tap ${TESTS}
 
 travis:
 	NODE_ENV=test ${MONGO_SETTINGS} \
-	${ISTANBUL} cover ${MOCHA} --report lcovonly -- -vvv -R tap ${TESTS}
+	${ISTANBUL} cover ${MOCHA} --report lcovonly -- -R tap ${TESTS}

--- a/Makefile
+++ b/Makefile
@@ -7,22 +7,26 @@ MONGO_SETTINGS=MONGO_CONNECTION=${MONGO_CONNECTION} \
 	CUSTOMCONNSTR_mongo_collection=${CUSTOMCONNSTR_mongo_collection} \
 	CUSTOMCONNSTR_mongo_settings_collection=${CUSTOMCONNSTR_mongo_settings_collection}
 
-MOCHA=$(shell which mocha ./node_modules/mocha/bin/_mocha)
+# XXX.bewest: Mocha is an odd process, and since things are being wrapped and
+# transformed, this odd path needs to be used, not the normal wrapper.
+# When ./node_modules/.bin/mocha is used, no coverage information is generated.
+MOCHA=$(shell which mocha ./node_modules/mocha/bin/_mocha | head -n 1)
+ISTANBUL=$(shell which istanbul ./node_modules/.bin/istanbul | head -n 1)
 
-.PHONY: all coverage test travis report
+.PHONY: all coverage report test travis
 
 all: test
 
 coverage:
 	NODE_ENV=test ${MONGO_SETTINGS} \
-	istanbul cover ${MOCHA} -- -vvv -R tap ${TESTS}
-
-test:
-	${MONGO_SETTINGS} ${MOCHA} --verbose -vvv -R tap ${TESTS}
+	${ISTANBUL} cover ${MOCHA} -- -vvv -R tap ${TESTS}
 
 report:
 	npm install coveralls && cat ./coverage/lcov.info | ./node_modules/.bin/coveralls
 
+test:
+	${MONGO_SETTINGS} ${MOCHA} --verbose -vvv -R tap ${TESTS}
+
 travis:
 	NODE_ENV=test ${MONGO_SETTINGS} \
-	istanbul cover ${MOCHA} --report lcovonly -- -vvv -R tap ${TESTS}
+	${ISTANBUL} cover ${MOCHA} --report lcovonly -- -vvv -R tap ${TESTS}

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ MONGO_SETTINGS=MONGO_CONNECTION=${MONGO_CONNECTION} \
 # coverage reporter's ability to instrument the tests correctly.
 # Hard coding it to the local with our pinned version is bigger for
 # initial installs, but ensures a consistent environment everywhere.
+# On Travis, ./node_modules/.bin and other `nvm` and `npm` bundles are
+# inserted into the default `$PATH` enviroinment, making pointing to
+# the unwrapped mocha executable necessary.
 MOCHA=./node_modules/mocha/bin/_mocha
 ISTANBUL=$(shell which istanbul ./node_modules/.bin/istanbul | head -n 1)
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ MONGO_SETTINGS=MONGO_CONNECTION=${MONGO_CONNECTION} \
 # XXX.bewest: Mocha is an odd process, and since things are being wrapped and
 # transformed, this odd path needs to be used, not the normal wrapper.
 # When ./node_modules/.bin/mocha is used, no coverage information is generated.
-MOCHA=$(shell which mocha ./node_modules/mocha/bin/_mocha | head -n 1)
+MOCHA=./node_modules/mocha/bin/_mocha
 ISTANBUL=$(shell which istanbul ./node_modules/.bin/istanbul | head -n 1)
 
 .PHONY: all coverage report test travis
@@ -23,6 +23,9 @@ coverage:
 	${ISTANBUL} cover ${MOCHA} -- -R tap ${TESTS}
 
 report:
+	# WAT?! ${PATH}
+	# ${MOCHA}
+	# $(shell which mocha ./node_modules/mocha/bin/_mocha | head -n 1)
 	test -f ./coverage/lcov.info && (npm install coveralls && cat ./coverage/lcov.info | ./node_modules/.bin/coveralls) || echo "NO COVERAGE"
 
 test:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 
+# Nightscout tests/builds/analysis
 TESTS=tests/*.js
 MONGO_CONNECTION?=mongodb://localhost/test_db
 CUSTOMCONNSTR_mongo_settings_collection?=test_settings

--- a/Makefile
+++ b/Makefile
@@ -19,13 +19,13 @@ all: test
 
 coverage:
 	NODE_ENV=test ${MONGO_SETTINGS} \
-	${ISTANBUL} cover ${MOCHA} -- -vvv -R tap ${TESTS}
+	${ISTANBUL} cover ${MOCHA} -- -R tap ${TESTS}
 
 report:
 	npm install coveralls && cat ./coverage/lcov.info | ./node_modules/.bin/coveralls
 
 test:
-	${MONGO_SETTINGS} ${MOCHA} --verbose -vvv -R tap ${TESTS}
+	${MONGO_SETTINGS} ${MOCHA} -R tap ${TESTS}
 
 travis:
 	NODE_ENV=test ${MONGO_SETTINGS} \

--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,14 @@ MONGO_SETTINGS=MONGO_CONNECTION=${MONGO_CONNECTION} \
 	CUSTOMCONNSTR_mongo_collection=${CUSTOMCONNSTR_mongo_collection} \
 	CUSTOMCONNSTR_mongo_settings_collection=${CUSTOMCONNSTR_mongo_settings_collection}
 
-# XXX.bewest: Mocha is an odd process, and since things are being wrapped and
-# transformed, this odd path needs to be used, not the normal wrapper.
-# When ./node_modules/.bin/mocha is used, no coverage information is generated.
+# XXX.bewest: Mocha is an odd process, and since things are being
+# wrapped and transformed, this odd path needs to be used, not the
+# normal wrapper.  When ./node_modules/.bin/mocha is used, no coverage
+# information is generated.  This happens because typical shell
+# wrapper performs process management that mucks with the test
+# coverage reporter's ability to instrument the tests correctly.
+# Hard coding it to the local with our pinned version is bigger for
+# initial installs, but ensures a consistent environment everywhere.
 MOCHA=./node_modules/mocha/bin/_mocha
 ISTANBUL=$(shell which istanbul ./node_modules/.bin/istanbul | head -n 1)
 
@@ -23,9 +28,6 @@ coverage:
 	${ISTANBUL} cover ${MOCHA} -- -R tap ${TESTS}
 
 report:
-	# WAT?! ${PATH}
-	# ${MOCHA}
-	# $(shell which mocha ./node_modules/mocha/bin/_mocha | head -n 1)
 	test -f ./coverage/lcov.info && (npm install coveralls && cat ./coverage/lcov.info | ./node_modules/.bin/coveralls) || echo "NO COVERAGE"
 
 test:

--- a/Makefile
+++ b/Makefile
@@ -7,17 +7,22 @@ MONGO_SETTINGS=MONGO_CONNECTION=${MONGO_CONNECTION} \
 	CUSTOMCONNSTR_mongo_collection=${CUSTOMCONNSTR_mongo_collection} \
 	CUSTOMCONNSTR_mongo_settings_collection=${CUSTOMCONNSTR_mongo_settings_collection}
 
-.PHONY: all coverage test travis
+MOCHA=$(shell which mocha ./node_modules/mocha/bin/_mocha)
+
+.PHONY: all coverage test travis report
 
 all: test
 
 coverage:
 	NODE_ENV=test ${MONGO_SETTINGS} \
-	istanbul cover ./node_modules/mocha/bin/_mocha -- -vvv -R tap ${TESTS}
+	istanbul cover ${MOCHA} -- -vvv -R tap ${TESTS}
 
 test:
-	${MONGO_SETTINGS} mocha --verbose -vvv -R tap ${TESTS}
+	${MONGO_SETTINGS} ${MOCHA} --verbose -vvv -R tap ${TESTS}
+
+report:
+	npm install coveralls && cat ./coverage/lcov.info | ./node_modules/.bin/coveralls
 
 travis:
 	NODE_ENV=test ${MONGO_SETTINGS} \
-	istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -vvv -R tap ${TESTS}
+	istanbul cover ${MOCHA} --report lcovonly -- -vvv -R tap ${TESTS}

--- a/Makefile
+++ b/Makefile
@@ -20,9 +20,9 @@ MONGO_SETTINGS=MONGO_CONNECTION=${MONGO_CONNECTION} \
 # inserted into the default `$PATH` enviroinment, making pointing to
 # the unwrapped mocha executable necessary.
 MOCHA=./node_modules/mocha/bin/_mocha
-ISTANBUL=$(shell which istanbul ./node_modules/.bin/istanbul | head -n 1)
-
-.PHONY: all coverage report test travis
+# Pinned from dependency list.
+ISTANBUL=./node_modules/.bin/istanbul
+ANALYZED=./coverage/lcov.info
 
 all: test
 
@@ -31,7 +31,9 @@ coverage:
 	${ISTANBUL} cover ${MOCHA} -- -R tap ${TESTS}
 
 report:
-	test -f ./coverage/lcov.info && (npm install coveralls && cat ./coverage/lcov.info | ./node_modules/.bin/coveralls) || echo "NO COVERAGE"
+	test -f ${ANALYZED} && \
+    (npm install coveralls && cat ${ANALYZED} | \
+      ./node_modules/.bin/coveralls) || echo "NO COVERAGE"
 
 test:
 	${MONGO_SETTINGS} ${MOCHA} -R tap ${TESTS}
@@ -39,3 +41,5 @@ test:
 travis:
 	NODE_ENV=test ${MONGO_SETTINGS} \
 	${ISTANBUL} cover ${MOCHA} --report lcovonly -- -R tap ${TESTS}
+
+.PHONY: all coverage report test travis


### PR DESCRIPTION
Figure out where mocha is and assign it to variable.  Also, isolate bash
execution/interpretation to one a single environment.  There is some evidence
that the interpretation is slightly modified somehow; if scripts need to be
run, we can run them all from Makefile to that things can be tested locally by
hand as well as automatically.  Scripts are also ok, but this is a small enough
change the Makefile seems fine.
